### PR TITLE
Potential fix for code scanning alert no. 213: Uncontrolled data used in path expression

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -9572,9 +9572,16 @@ var limiter = RateLimit({
 app.use(limiter);
 
 app.get('/:path', function(req, res) {
-  let path = req.params.path;
-  if (isValidPath(path))
-    res.sendFile(path);
+  const userPath = req.params.path;
+  const publicRoot = path4.resolve(import.meta.dirname, "public");
+  // Safe resolution: join with public root and check containment
+  const resolvedPath = fs3.realpathSync(path4.resolve(publicRoot, userPath));
+  if (!resolvedPath.startsWith(publicRoot)) {
+    // Attempted path traversal or access outside public dir
+    res.status(403).send('Forbidden');
+    return;
+  }
+  res.sendFile(resolvedPath);
 });
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/anumethod/ihep/security/code-scanning/213](https://github.com/anumethod/ihep/security/code-scanning/213)

The best way to fix the problem is to ensure that any file path derived from user input is normalized and enforced to stay within a designated root directory (e.g., the public folder). This fix should be applied to the route handler at lines 9574–9578. 

Specifically:
- Use `path.resolve()` to join the root public directory with the user-provided filename, normalizing the path and removing any traversal segments.
- Use `fs.realpathSync` to further resolve symlinks and ensure the file is truly within the allowed root directory.
- Check that the resulting path starts with the root public folder path. If not, reject the request (send 403 Forbidden).
- Only proceed to send the file if the path passes all validation checks.

You may need to require/import the `path` and `fs` modules if they're not already present in the snippet. Limit changes only to the code shown — for this fix, you can assume the use of Node's standard `path` and `fs` modules.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
