### PR TITLE
Potential fix for code scanning alert no. 232: Clear-text logging of sensitive information

### DIFF
--- a/python/dt-backend-synthesis-engine.py
+++ b/python/dt-backend-synthesis-engine.py
@@ -1207,7 +1207,9 @@ async def demo_synthesis_service():
     
     for patient_id in patient_ids:
         await service.request_patient_update(patient_id, priority=1)
-        print(f"✓ Requested update for {patient_id}")
+        # Log only a hashed version of patient_id for privacy
+        hashed_pid = hashlib.sha256(patient_id.encode()).hexdigest()[:8]
+        print(f"✓ Requested update for patient id [hash: {hashed_pid}]")
     
     # Let service process updates
     print("\n[Processing] Allowing service to process updates...")


### PR DESCRIPTION
Potential fix for [https://github.com/anumethod/ihep/security/code-scanning/232](https://github.com/anumethod/ihep/security/code-scanning/232)

To address the issue, the code should avoid logging patient identifiers in clear-text. The fix should:
- Redact or anonymize the patient identifier before logging. A typical fix is to log only a truncated, hashed, pseudonymized, or masked version of the ID (e.g., use a digest or only display the last 4 characters).
- This change only affects the demonstration code's logging—specifically line 1210.
- The best way without affecting current behavior (demonstration traces) is to hash the patient_id and log only a few characters of the hash (e.g., 8 hex digits), which allows tracking events for individual patients without revealing the real identifier.
- To do this, we will use the already-imported `hashlib` to hash the patient_id, and change the print statement to:  
  `print(f"✓ Requested update for patient id [hash: {hashed_pid}]")`  
  Where `hashed_pid` is `hashlib.sha256(patient_id.encode()).hexdigest()[:8]` or similar.
- No additional imports are needed; we can use `hashlib` since it's already in the snippet.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
