### PR TITLE
Potential fix for code scanning alert no. 237: Clear-text logging of sensitive information

### DIFF
--- a/python/ihep-healthcare-api.py
+++ b/python/ihep-healthcare-api.py
@@ -473,7 +473,7 @@ def deidentify_patient_data(patient_id):
             success=True
         )
         
-        logger.info(f"De-identified data for patient {patient_id}")
+        logger.info(f"De-identified data for patient [REDACTED]")
         
         return jsonify({
             'message': 'De-identification completed',


### PR DESCRIPTION
Potential fix for [https://github.com/anumethod/ihep/security/code-scanning/237](https://github.com/anumethod/ihep/security/code-scanning/237)

To fix the issue, we should avoid logging the actual `patient_id` in clear text. Instead, we can log a pseudonymized, hashed, or redacted version of the ID, so that audit and debugging remain possible without exposing sensitive information. The recommended approach is to log only a securely hashed (e.g., SHA-256) or a truncated derivative (such as the last N characters) that cannot be easily mapped back to the actual patient ID, or replace it with a fixed string such as `[REDACTED]`. 

**Detailed fix plan:**  
- In the log message on line 476, avoid emitting the raw `patient_id`.
- Log either `[REDACTED]` as a placeholder, or (if absolutely needed for incident correlation) log a hashed value, e.g., `hashlib.sha256(patient_id.encode()).hexdigest()[:8]` as a short, nonreversible identifier.
- If `hashlib` is not imported in the shown code, add the appropriate import statement.
- Only adjust the logging statement; no functional behavior (API, business logic) should change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
