### PR TITLE
Potential fix for code scanning alert no. 236: Clear-text logging of sensitive information

### DIFF
--- a/python/ihep-healthcare-api.py
+++ b/python/ihep-healthcare-api.py
@@ -198,7 +198,7 @@ def get_patient(patient_id):
         return jsonify(patient_data), 200
         
     except exceptions.NotFound:
-        logger.info(f"Patient {patient_id} not found")
+        logger.info("Patient resource not found")  # Omit patient_id from logs for privacy
         return jsonify({'error': 'Patient not found'}), 404
     except exceptions.GoogleAPIError as e:
         logger.error(f"Error retrieving patient: {str(e)}")


### PR DESCRIPTION
Potential fix for [https://github.com/anumethod/ihep/security/code-scanning/236](https://github.com/anumethod/ihep/security/code-scanning/236)

To fix the problem, avoid logging the clear-text value of `patient_id` in application logs. Instead, log only non-sensitive information or use a safe surrogate, such as a hashed version of the ID (with a properly salted hash to avoid rainbow table lookups), or omit it entirely from low-level info/debug logs. If context is needed for legitimate debugging, a hash or truncated surrogate is preferred over the raw ID.

Specifically:
- Edit line 201 in python/ihep-healthcare-api.py to remove or mask the `patient_id` in the log message.
- If context is needed, replace it (for instance) with a SHA256 hash (with static salt) or a generic message like "A patient not found".
- Add the required import if using `hashlib`.
- If patient_id context is not necessary, simply log "Patient not found" without quoting the ID.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
