### PR TITLE
Fix urllib3 security vulnerabilities (CVE-2025-66418, CVE-2025-66471)

### DIFF
--- a/applications/backend/requirements.txt
+++ b/applications/backend/requirements.txt
@@ -35,7 +35,7 @@ bcrypt==4.2.1
 
 # HTTP Requests
 requests==2.32.5
-urllib3==2.5.0
+urllib3==2.6.0
 
 # Data Validation & Serialization
 marshmallow==3.23.2


### PR DESCRIPTION
Update urllib3 from 2.5.0 to 2.6.0 to address:
- CVE-2025-66418: Unbounded number of links in decompression chain allowing high CPU usage and memory allocation attacks
- CVE-2025-66471: Streaming API improper handling of highly compressed data leading to potential DoS via decompression bombs

Both vulnerabilities are rated High severity and affect urllib3 < 2.6.0.