### PR TITLE
fix(security): Patch critical and high severity vulnerabilities in Py…

### DIFF
--- a/applications/backend/requirements.txt
+++ b/applications/backend/requirements.txt
@@ -32,6 +32,7 @@ google-cloud-secret-manager==2.25.0
 # Security & Cryptography
 cryptography==46.0.3
 bcrypt==4.2.1
+filelock>=3.20.1  # Pinned for CVE-2025-68146 fix (TOCTOU symlink vulnerability)
 
 # HTTP Requests
 requests==2.32.5

--- a/curriculum-backend/requirements.txt
+++ b/curriculum-backend/requirements.txt
@@ -1,7 +1,7 @@
 # IHEP Curriculum Backend - Production Requirements
 
 # Core Framework
-fastapi==0.109.0
+fastapi>=0.115.3
 uvicorn[standard]==0.27.0
 pydantic==2.5.3
 pydantic-settings==2.1.0
@@ -21,9 +21,9 @@ celery==5.3.6
 kombu==5.3.5
 
 # Authentication & Security
-python-jose[cryptography]==3.3.0
+PyJWT[crypto]>=2.8.0
 passlib[argon2]==1.7.4
-python-multipart==0.0.6
+python-multipart>=0.0.18
 pyotp==2.9.0
 qrcode[pil]==7.4.2
 argon2-cffi==23.1.0
@@ -52,14 +52,14 @@ numpy==1.26.3
 scipy==1.12.0
 
 # Development
-black==23.12.1
+black>=24.3.0
 flake8==7.0.0
 mypy==1.8.0
 pre-commit==3.6.0
 
 # Monitoring
 prometheus-client==0.19.0
-sentry-sdk==1.39.2
+sentry-sdk>=1.45.1
 
 # Documentation
 mkdocs==1.5.3


### PR DESCRIPTION
…thon dependencies

- Replace python-jose with PyJWT[crypto]>=2.8.0 (fixes CVE-2024-33663 algorithm confusion with ECDSA keys and CVE-2024-33664 DoS via compressed JWE)
- Update fastapi>=0.115.3 to pull starlette>=0.40.0 (fixes CVE-2024-47874 DoS via multipart/form-data)
- Update python-multipart>=0.0.18 (fixes CVE-2024-24762 ReDoS and CVE-2024-53981 DoS)
- Update black>=24.3.0 (fixes CVE-2024-21503 ReDoS)
- Update sentry-sdk>=1.45.1 (fixes CVE-2024-40647 environment variable exposure)
- Pin filelock>=3.20.1 (fixes CVE-2025-68146 TOCTOU symlink attack)

The ecdsa dependency vulnerability is resolved by switching from python-jose (which depends on ecdsa) to PyJWT with cryptography backend.