### PR TITLE
fix(security): Patch critical and high severity vulnerabilities in Py…

### DIFF
--- a/applications/backend/requirements.txt
+++ b/applications/backend/requirements.txt
@@ -39,7 +39,7 @@ requests==2.32.5
 urllib3==2.6.1
 
 # Data Validation & Serialization
-marshmallow==3.23.2
+marshmallow>=4.1.2  # Pinned for CVE-2025-68480 fix (DoS in Schema.load)
 
 # Environment Variables
 python-dotenv==1.0.1
@@ -74,8 +74,8 @@ bandit==1.8.0
 safety==3.2.11
 
 # ML Training Dependencies (for MedGemma fine-tuning)
-torch>=2.1.0
-transformers>=4.36.0
+torch>=2.6.0  # Pinned for CVE-2025-32434 (RCE), CVE-2024-31580 (heap overflow), CVE-2024-31583 (use-after-free)
+transformers>=4.48.0  # Pinned for CVE-2024-11392/11393/11394 (deserialization RCE) and ReDoS fixes
 datasets>=2.16.0
 accelerate>=0.25.0
 peft>=0.7.0
@@ -85,5 +85,5 @@ tensorboard>=2.15.0
 evaluate>=0.4.1
 scipy>=1.11.0
 pyyaml>=6.0
-tqdm>=4.66.0
+tqdm>=4.66.3  # Pinned for CVE-2024-34062 fix (CLI injection)
 


### PR DESCRIPTION
…thon dependencies

Update minimum versions for vulnerable packages:
- transformers: >=4.48.0 (CVE-2024-11392/11393/11394 deserialization RCE + ReDoS)
- torch: >=2.6.0 (CVE-2025-32434 RCE, CVE-2024-31580 heap overflow, CVE-2024-31583 use-after-free)
- marshmallow: >=4.1.2 (CVE-2025-68480 DoS in Schema.load)
- tqdm: >=4.66.3 (CVE-2024-34062 CLI injection)