### PR TITLE
ci: add least-privilege permissions to workflows (CodeQL)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,6 @@
+permissions:
+  contents: read
+
 name: CI
 
 on:

--- a/.github/workflows/cpanel-deploy.yml
+++ b/.github/workflows/cpanel-deploy.yml
@@ -1,3 +1,6 @@
+permissions:
+  contents: read
+
 name: Deploy to cPanel
 
 on:


### PR DESCRIPTION
Adds top-level `permissions: contents: read` to both GitHub Actions workflows to satisfy the CodeQL rule "Workflow does not contain permissions".

Resolves 9 code scanning alerts:
- ci.yml — 6 jobs (lint, test, build, security, validate-crypto, summary)
- cpanel-deploy.yml — 3 jobs (deploy, security-scan, post-deployment)

Every job only reads repository contents (checkout/build/audit) or uses deployment secrets over SSH; none needs elevated GITHUB_TOKEN scopes, so read is the least-privilege floor.

Supersedes #57.

Author: Jason M Jarmacz | Evolution Strategist
Co-Author: Claude by Anthropic
Human/AI Innovative Collaboration